### PR TITLE
Changed CentOS and OracleLinux composes

### DIFF
--- a/dispatcher/__init__.py
+++ b/dispatcher/__init__.py
@@ -19,12 +19,12 @@ COPR_CONFIG = {"copr_url": "https://copr.fedorainfracloud.org"}
 COMPOSE_MAPPING = {
     "cos8": {
         "compose": "CentOS-8-latest",
-        "distro": "centos-8",
+        "distro": "centos-8-latest",
         "chroot": "epel-8-x86_64",
     },
     "ol8": {
         "compose": "Oracle-Linux-8.6",
-        "distro": "oraclelinux-8",
+        "distro": "oraclelinux-8.6",
         "chroot": "epel-8-x86_64",
     },
     "cos7": {


### PR DESCRIPTION
Updated `centos-8` compose to `centos-8-latest`, as well as explicitelly updating to use `oraclelinux-8.6` instead of just `oraclelinux-8`.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>