### PR TITLE
Workaround AWS releasing guests

### DIFF
--- a/dispatcher/__init__.py
+++ b/dispatcher/__init__.py
@@ -186,6 +186,13 @@ Default: '%(default)s'""",
         help="""Choose composes to run tests on.\nDefault: '%(default)s'.""",
     )
 
+    parser.add_argument(
+        "-pw",
+        "--pool-workaround",
+        action="store_true",
+        help="""Workarounds the AWS spot instances release.""",
+    )
+
     # TODO tesar file path
     # parser.add_argument(
     #     "-cfg",

--- a/dispatcher/__main__.py
+++ b/dispatcher/__main__.py
@@ -80,15 +80,19 @@ def main():
         sys.exit(99)
 
     for plan in args.plans:
+        # Usually the best approach is to let Testing Farm to choose the most suitable pool.
+        # Recently the AWS pools are releasing the guests during test execution.
+        # If the pool-workaround option is passed, use the baseosci-openstack pool
+        pool = ""
+        if args.pool_workaround:
+            pool = "baseosci-openstack"
+            logger.warning("Pool workaround option detected, requesting 'baseosci-openstack' pool for this run.")
 
         if args.compose:
             info, build_reference = artifact_module.get_info(
                 PACKAGE_MAPPING[args.package], reference, args.compose
             )
         else:
-            # Disable Oracle Linux 8.4 as default.
-            # Keep it in the mapping in case needed.
-            COMPOSE_MAPPING.pop('ol84')
             info, build_reference = artifact_module.get_info(
                 PACKAGE_MAPPING[args.package],
                 reference,
@@ -111,6 +115,7 @@ def main():
                 plan,
                 args.architecture,
                 build["compose"],
+                pool,
                 str(build["build_id"]),
                 ARTIFACT_MAPPING[args.artifact_type],
                 PACKAGE_MAPPING[args.package],

--- a/dispatcher/tf_send_request.py
+++ b/dispatcher/tf_send_request.py
@@ -24,6 +24,7 @@ def submit_test(
     plan,
     architecture,
     compose,
+    pool,
     artifact_id,
     artifact_type,
     package,
@@ -49,6 +50,7 @@ def submit_test(
             {
                 "arch": architecture,
                 "os": {"compose": compose},
+                "pool": pool,
                 "artifacts": [
                     {
                         "id": artifact_id,


### PR DESCRIPTION
* add -pw/--pool-workaround option to workaround the failing pipeline because of the AWS releasing guest prematurely
* if passed, the option requests the 'baseosci-openstack' pool
* resolves #10