### PR TITLE
Warn if build non existent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).<br>
 - `-u/--uefi` test option to request target with UEFI boot mode
 - CentOS Stream 8 target
 - `--parallel-limit` limit of plans to be run in parallel, default 42
+- query for task ID, warn and exit if build doesn't match requested test artifact
 
 ### Changed
 - `-c/--compose` to `-t/--target`

--- a/src/dispatch/__init__.py
+++ b/src/dispatch/__init__.py
@@ -113,7 +113,7 @@ def get_arguments(args=None):
     reference.add_argument(
         "-ref",
         "--reference",
-        nargs="+",
+        nargs=1,
         help=f"""{FormatText.bold}Mutually exclusive with respect to --task-id.{FormatText.end}
 For brew: Specify the reference version to find the correct artifact (e.g. 0.1-2, 0.1.2).
 For copr: Specify the pull request reference to find the correct artifact (e.g. pr123, main, master, ...).""",
@@ -122,7 +122,7 @@ For copr: Specify the pull request reference to find the correct artifact (e.g. 
     reference.add_argument(
         "-id",
         "--task-id",
-        nargs="+",
+        nargs=1,
         help=f"""{FormatText.bold}Mutually exclusive with respect to --reference.{FormatText.end}
 For brew: Specify the TASK ID for required brew build.
 {FormatText.bold}NOTE: Double check, that you are passing TASK ID for copr builds, not BUILD ID otherwise testing farm will not install the package.{FormatText.end}

--- a/src/report/__main__.py
+++ b/src/report/__main__.py
@@ -124,7 +124,7 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
         request_state = request.json()["state"].upper()
         request_uuid = request.json()["id"]
         request_target = request.json()["environments_requested"][0]["os"]["compose"]
-        request_arch = request.json()["environments_requested"][0]['arch']
+        request_arch = request.json()["environments_requested"][0]["arch"]
         request_datetime_created = request.json()["created"]
         request_datetime_parsed = request_datetime_created.split(".")[0]
 
@@ -231,7 +231,9 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
             # it consist of only the plan name
             testsuite_name = elem.xpath("./@name")[0].split(":")[-1]
             try:
-                testsuite_arch = elem.xpath("./testing-environment/property[@name='arch']/@value")[0]
+                testsuite_arch = elem.xpath(
+                    "./testing-environment/property[@name='arch']/@value"
+                )[0]
             except IndexError:
                 testsuite_arch = elem.xpath("./@name")[0].split(":")[1]
             testsuite_result = elem.xpath("./@result")[0].upper()

--- a/src/report/__main__.py
+++ b/src/report/__main__.py
@@ -433,7 +433,6 @@ def build_table():
     if ARGS.split_planname:
         planname_split_index = ARGS.split_planname
 
-
     def _gen_row(uuid="", target="", arch="", testplan="", testcase="", result=""):
         if "UUID" in fields:
             yield uuid


### PR DESCRIPTION
* refactor get_info() in copr_api module
* add warning, when referenced build is not found in the query
* modify reference and build_id nargs to accept only one option
* warn and exit when build_id doesn't point to correct project/package
  and/or the state of the build is failed
* add docstrings 

Fixes #33, #51