### PR TITLE
Handle no target specified for leapp-repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).<br>
 - `-c/--compose` to `-t/--target`
 - bump mapped convert2rhel composes/targets to Alma Linux and Rocky Linux 8.9, Oracle Linux 8.8
    (8.9 is absent on the AWS marketplace)
+- use all mapped compose targets when `-t/--target` not specified for the leapp-repository package
 ### Removed
 ## [2023.07.12]
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Multiple `--plans` can be specified and will be dispatched in separate jobs. The
 You can look for possible [targeted OS' below](#mapped-composes), multiple can be requested and will be dispatched in separate jobs.
 Use `-w/--wait` to override the default 20 seconds waiting time for successful response from the endpoint, or `-nw/--no-wait` to skip the wait time.
 If for any reason you would need the raw payload, use `--dry-run` to get it printed to the command line or use `--dry-run-cli` to print out the full usable `http POST` command.
-
+When no `-t/--target` option is specified, the request is sent for all mapped target composes for their respective tested packages.
 ```shell
 ❯ tesar test --help
 usage: tesar test [-h] (-ref REFERENCE [REFERENCE ...] | -id TASK_ID [TASK_ID ...]) [-g GIT [GIT ...]] [-gp GIT_PATH] [-a ARCHITECTURE] (-p PLANS [PLANS ...] | -pf PLANFILTER [PLANFILTER ...] | -tf TESTFILTER [TESTFILTER ...])

--- a/src/dispatch/__init__.py
+++ b/src/dispatch/__init__.py
@@ -320,6 +320,8 @@ def get_compose_mapping(args=None):
     """Dynamically provide proper compose mapping depending on cli args"""
     args = get_arguments(args=args or sys.argv[1:])
 
-    compose_mapping = {('test', 'c2r'): dispatch_globals.C2R_COMPOSE_MAPPING,
-                       ('test', 'leapp-repository'): dispatch_globals.LP_COMPOSE_MAPPING}
+    compose_mapping = {
+        ("test", "c2r"): dispatch_globals.C2R_COMPOSE_MAPPING,
+        ("test", "leapp-repository"): dispatch_globals.LP_COMPOSE_MAPPING,
+    }
     return compose_mapping.get((args.action, args.package), {})

--- a/src/dispatch/__main__.py
+++ b/src/dispatch/__main__.py
@@ -22,8 +22,6 @@ def main():
     copr_repo = PACKAGE_MAPPING[ARGS.package]
     copr_package = PACKAGE_MAPPING[ARGS.package]
     git_repo = PACKAGE_MAPPING.get(ARGS.package)
-    source_release = ""
-    target_release = ""
     if ARGS.package == "leapp-repository":
         git_repo = "leapp-tests"
         copr_repo = "leapp"

--- a/src/dispatch/copr_api.py
+++ b/src/dispatch/copr_api.py
@@ -89,7 +89,6 @@ def get_build_dictionary(
 
     LOGGER.info(f"Built at {build_time}")
     LOGGER.info(f"LINK: {build_baseurl}{build.id}")
-    release_var_iter = 0
     for distro in composes:
         copr_info_dict = {
             "build_id": None,
@@ -101,16 +100,14 @@ def get_build_dictionary(
         }
         # Assign correct SOURCE_RELEASE and TARGET_RELEASE
         if ARGS.package == "leapp-repository":
-            release_vars = ARGS.target[release_var_iter]
-            source_release_raw = str(release_vars.split("to")[0])
-            target_release_raw = str(release_vars.split("to")[1])
+            source_release_raw = str(distro.split("to")[0])
+            target_release_raw = str(distro.split("to")[1])
             source_release = f"{source_release_raw[0]}.{source_release_raw[1]}"
             target_release = f"{target_release_raw[0]}.{target_release_raw[1]}"
         copr_info_dict["compose"] = COMPOSE_MAPPING.get(distro).get("compose")
         copr_info_dict["distro"] = COMPOSE_MAPPING.get(distro).get("distro")
         copr_info_dict["source_release"] = source_release
         copr_info_dict["target_release"] = target_release
-        release_var_iter += 1
         for chroot in build.chroots:
             if COMPOSE_MAPPING.get(distro).get("chroot") == chroot:
                 copr_info_dict["chroot"] = COMPOSE_MAPPING.get(distro).get("chroot")

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -9,12 +9,23 @@ from dispatch import get_arguments
 def test_cmd_args_are_appended():
     """Unit test covering tesar report -c test1 -c test2 behavior for results aggregation"""
     # Make sure -c are treated as list
-    args = get_arguments(['report',
-         '-c', 'http://artifacts.osci.redhat.com/testing-farm/909143cf-89ca-4d62-8f81-959bf8ab4d03/',
-         '-c', 'http://artifacts.osci.redhat.com/testing-farm/14612a82-002d-4a8d-a5c4-613a0a75efeb/'])
+    args = get_arguments(
+        [
+            "report",
+            "-c",
+            "http://artifacts.osci.redhat.com/testing-farm/909143cf-89ca-4d62-8f81-959bf8ab4d03/",
+            "-c",
+            "http://artifacts.osci.redhat.com/testing-farm/14612a82-002d-4a8d-a5c4-613a0a75efeb/",
+        ]
+    )
     assert len(args.cmd) == 2
     # Make official the behavior that -c test1 test2 test3 is not supported anymore
     with pytest.raises(SystemExit):
-        get_arguments(['report', '-c',
-                       'http://artifacts.osci.redhat.com/testing-farm/909143cf-89ca-4d62-8f81-959bf8ab4d03/',
-                       'http://artifacts.osci.redhat.com/testing-farm/14612a82-002d-4a8d-a5c4-613a0a75efeb/'])
+        get_arguments(
+            [
+                "report",
+                "-c",
+                "http://artifacts.osci.redhat.com/testing-farm/909143cf-89ca-4d62-8f81-959bf8ab4d03/",
+                "http://artifacts.osci.redhat.com/testing-farm/14612a82-002d-4a8d-a5c4-613a0a75efeb/",
+            ]
+        )


### PR DESCRIPTION
* When no target was specified for leapp-repository the utility failed to parse None type objects
* Handle the same way as for c2r, when no target specified dispatch for all mapped targets/upgrade paths

Fixes #36