### PR TITLE
Redefine default test location for leapp-repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ and this project adheres to [Calendar Versioning](https://calver.org).<br>
    (8.9 is absent on the AWS marketplace)
 - use all mapped compose targets when `-t/--target` not specified for the leapp-repository package
 - make `--plans`, `--planfilter` and `--testfilter` compatible
+- `-g/--git` accepts 4 arguments - base (github, gitlab, gitlab.cee.redhat), repo owner, repo name, git reference (branch, etc.)
+- `gitlab.cee.redhat.com/oamg/leapp-tests/-/tree/master` set as default location for tests if `-g/--git` is not specified
+- git reference can be specified for leapp-repository tests
 ### Removed
+
 ## [2023.07.12]
 ### Added
 - `-s/--short` display short test and plan names

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ As of now tesar is able to perform two tasks.
 The goal of tesar is to make requesting test jobs as easy as possible.<br>
 Instead of looking for build IDs to pass to the payload, all you need to know is a `--reference` for a pull request number associated with the build you need to test. For brew builds you just need to know the release version.<br>
 In case you have the Build ID handy, you can use that instead of the reference.<br>
-Use `-g/--git` to point from where the test metadata and code should be run. Specify the repository base e.g. github, repository owner and the branch from which the tests should run.<br>
-Multiple `--plans` can be specified and will be dispatched in separate jobs.
+Use `-g/--git` to point from where the test metadata and code should be run. Specify the repository base e.g. github, repository owner, repository name and the branch from which the tests should run.<br>
+Multiple `--plans` can be specified and will be dispatched in separate jobs.<br>
 When using `--planfilter` or `--testfilter` to specify singular test it is disallowed to request multiple `--plans` in one command.<br>
 You can look for possible [targeted OS' below](#mapped-composes), multiple can be requested and will be dispatched in separate jobs.
 Use `-w/--wait` to override the default 20 seconds waiting time for successful response from the endpoint, or `-nw/--no-wait` to skip the wait time.

--- a/src/tesar/dispatch/__init__.py
+++ b/src/tesar/dispatch/__init__.py
@@ -132,10 +132,8 @@ For copr: Specify the BUILD ID for required copr build.""",
     test.add_argument(
         "-g",
         "--git",
-        nargs="+",
-        default=["github", "oamg", "main"],
-        help="""Provide repository base (github, gitlab, gitlab.cee.redhat)\nowner of the repository\nand a branch containing the tests you want to run.
-Default: '%(default)s'""",
+        nargs=4,
+        help="""Provide repository base (github, gitlab, gitlab.cee.redhat) owner of the repository, repository name and a branch containing the tests you want to run.""",
     )
 
     test.add_argument(

--- a/src/tesar/dispatch/__main__.py
+++ b/src/tesar/dispatch/__main__.py
@@ -18,26 +18,39 @@ ARGS = get_arguments()
 COMPOSE_MAPPING = get_compose_mapping()
 
 
-def main():
-    copr_repo = PACKAGE_MAPPING[ARGS.package]
-    copr_package = PACKAGE_MAPPING[ARGS.package]
-    git_repo = PACKAGE_MAPPING.get(ARGS.package)
-    if ARGS.package == "leapp-repository":
+def main(
+    git_base=None,
+    git_owner=None,
+    git_repo=None,
+    git_ref=None,
+    copr_repo=None,
+    copr_package=PACKAGE_MAPPING[ARGS.package],
+):
+    if ARGS.package == "c2r":
+        git_base = "github"
+        git_owner = "oamg"
+        git_repo = PACKAGE_MAPPING.get(ARGS.package)
+        git_ref = "main"
+        copr_repo = PACKAGE_MAPPING[ARGS.package]
+    elif ARGS.package == "leapp-repository":
+        git_base = "gitlab.cee.redhat"
+        git_owner = "oamg"
         git_repo = "leapp-tests"
+        git_ref = "master"
         copr_repo = "leapp"
-
+    if ARGS.git:
+        git_base = ARGS.git[0]
+        if ".com" in git_base:
+            git_base = git_base.strip(".com")
+        git_owner = ARGS.git[1]
+        git_repo = ARGS.git[2]
+        git_ref = ARGS.git[3]
     try:
-        repo_base_url = "https://{}.com/{}/{}".format(
-            ARGS.git[0], ARGS.git[1], git_repo
-        )
+        repo_base_url = "https://{}.com/{}/{}".format(git_base, git_owner, git_repo)
         git_response = requests.get(repo_base_url)
-        if (
-            ARGS.git[0] != "gitlab"
-            and ARGS.git[0] != "github"
-            and ARGS.git[0] != "gitlab.cee.redhat"
-        ):
+        if git_base not in ["gitlab", "github", "gitlab.cee.redhat"]:
             LOGGER.critical(
-                "Bad git base reference, please provide correct values.\ngithub / gitlab"
+                "Bad git base reference, please provide correct values.\ngithub / gitlab / gitlab.cee.redhat"
             )
             sys.exit(99)
         elif git_response.status_code == 404:
@@ -90,7 +103,7 @@ def main():
     for plan in plans:
         item = plan.rstrip("/")
         # Usually the best approach is to let Testing Farm to choose the most suitable pool.
-        # Recently the AWS pools are releasing the guests during test execution.
+        # Occasionally the AWS pools are releasing the guests during test execution.
         # If the pool-workaround option is passed, use the baseosci-openstack pool
         pool = ""
         if ARGS.pool_workaround:
@@ -123,7 +136,7 @@ def main():
                 )
             submit_test(
                 repo_base_url,
-                ARGS.git[2],
+                git_ref,
                 ARGS.git_path,
                 plan,
                 ARGS.planfilter,

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -29,3 +29,50 @@ def test_cmd_args_are_appended():
                 "http://artifacts.osci.redhat.com/testing-farm/14612a82-002d-4a8d-a5c4-613a0a75efeb/",
             ]
         )
+        get_arguments(
+            [
+                "report",
+                "-c",
+                "http://artifacts.osci.redhat.com/testing-farm/909143cf-89ca-4d62-8f81-959bf8ab4d03/",
+                "http://artifacts.osci.redhat.com/testing-farm/14612a82-002d-4a8d-a5c4-613a0a75efeb/",
+            ]
+        )
+
+
+def test_git_arg_four_nargs():
+    """Unit test covering tesar test -g accepting four arguments."""
+    # Pass all four arguments to the --git arg
+    args = get_arguments(
+        [
+            "test",
+            "copr",
+            "c2r",
+            "-r",
+            "pr123",
+            "-p",
+            "mock_plan",
+            "-g",
+            "github",
+            "oamg",
+            "convert2rhel",
+            "devel",
+        ]
+    )
+    assert len(args.git) == 4
+    # Pass less than 4 arguments
+    with pytest.raises(SystemExit):
+        get_arguments(
+            [
+                "test",
+                "copr",
+                "c2r",
+                "-r",
+                "pr123",
+                "-p",
+                "mock_plan",
+                "-g",
+                "github",
+                "oamg",
+                "devel",
+            ]
+        )


### PR DESCRIPTION
* without `-g/--git` the script was resolving the default test repository url poorly, user forced to specify as commandline option
* additionally user was unable to select a branch/git reference when specifying the leapp-tests location on the commandline
* with the fix the default leapp-tests repository is defined without the git argument needed
* make git option accept four args - baseurl, repo owner, repo name and git branch/reference to checkout
* add simple test covering the git argument
* resolves #37 
* additional changes made by pre-commit hook