### PR TITLE
Introduce comparison between 2 test runs mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).<br>
 ### Added
 - Return code for report command
 - Report command option for downloading logs only for non-passed tests
+- Test results comparison mode introduced, can be controlled by the `--compare` option of `tesar report`.
 
 ### Changed
 - `-c/--compose` to `-t/--target`

--- a/README.md
+++ b/README.md
@@ -204,9 +204,17 @@ Corresponding return code is set based on the results with following logic:
  * 4 - At least one request didn't have any result
  * everything else - consult with Tesar maintainer(s)
 
+The default way to show results is by showing each run details as a separate table. In order to combine test results of several different tft runs you can use comparison mode which is triggered by the `--compare` flag of `tesar report`.
+
+```shell
+❯ tesar report -c 8f4e2e3e-beb4-4d3a-9b0a-68a2f428dd1b -c c3726a72-8e6b-4c51-88d8-612556df7ac1 --short  --unify-results=tier2=tier2_7to8 --compare
+```
+
+
+
 ```shell
 ❯ tesar report --help
-usage: tesar report [-h] [-l2] [-s] [-stn SPLIT_TESTNAME] [-spn SPLIT_PLANNAME] [-w] [-d] [--skip-pass] [-lt | -f FILE | -c CMD]
+usage: tesar report [-h] [-l2] [-s] [-stn SPLIT_TESTNAME] [-spn SPLIT_PLANNAME] [-w] [-d] [--skip-pass] [--compare] [-u UNIFY_RESULTS] [-lt | -f FILE | -c CMD]
 
 Parses task IDs, Testing Farm artifact URLs or Testing Farm API request URLs from multiple sources.
 
@@ -221,9 +229,12 @@ options:
   -w, --wait            Wait for the job to complete. Print the table afterwards
   -d, --download-logs   Download logs for requested run(s).
   --skip-pass           Skip PASSED results while showing table and while downloading logs.
+  --compare             Build a comparison table for several runs results
+  -u UNIFY_RESULTS, --unify-results UNIFY_RESULTS
+                        Plans name to be treated as one in plan1=plan2 format, useful for runs comparison in case of renaming.
   -lt, --latest         Mutually exclusive with respect to --file and --cmd. Report latest jobs from /tmp/tesar_latest_jobs.
-  -f FILE, --file FILE  Mutually exclusive with respect to --latest and --cmd. Specify a different location than the default ./report_jobs of the file containing request_id's, artifact URLs or request
-                        URLs.
+  -f FILE, --file FILE  Mutually exclusive with respect to --latest and --cmd. Specify a different location than the default ./report_jobs of the file containing request_id's, artifact URLs
+                        or request URLs.
   -c CMD, --cmd CMD     Mutually exclusive with respect to --file and --latest. Parse request_ids, artifact URLs or request URLs from the command line.
 ```
 

--- a/src/dispatch/__init__.py
+++ b/src/dispatch/__init__.py
@@ -295,6 +295,15 @@ Accepts multiple space separated values, sends as a separate request.""",
         action="store_true",
         help="Skip PASSED results while showing table and while downloading logs.",
     )
+    report.add_argument(
+        "--compare",
+        action="store_true",
+        help="""Build a comparison table for several runs results""")
+    report.add_argument(
+        "-u",
+        "--unify-results",
+        action="append",
+        help="""Plans name to be treated as one in plan1=plan2 format, useful for runs comparison in case of renaming.""")
     tasks_source = report.add_mutually_exclusive_group()
     tasks_source.add_argument(
         "-lt",

--- a/src/report/__main__.py
+++ b/src/report/__main__.py
@@ -182,6 +182,13 @@ Skipping to next request."""
             continue
 
         xunit = request.json()["result"]["xunit"]
+        #TODO: possibly always use artifacts/results.xml url instead of xunit in the TF endpoint
+        if not xunit:
+            results_xml_url = request.json()["run"]["artifacts"] + "/results.xml"
+            results_xml_response = requests.get(results_xml_url)
+            if results_xml_response:
+                xunit = results_xml_response.text
+
         xml = lxml.etree.fromstring(xunit.encode())
 
         job_result_overall = xml.xpath("/testsuites/@overall-result")[0]

--- a/src/report/__main__.py
+++ b/src/report/__main__.py
@@ -279,12 +279,24 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
 
 
 def _split_name(name, index):
+    """A helper that splits a test name at the position given by index"""
     name_raw = name.split("/")
     name_raw.remove("")
     return "/".join(name_raw[index:])
 
 
 def build_table_comparison():
+    """
+    Generate a table holding comparable results of several tests.
+
+    This allows a clear comparison of several tft runs with particular test
+    results side by side in respectable columns.
+    Sample format:
+    **     tft_run_uuid1  tft_run_uuid2
+    test1   PASS            FAIL
+    test2   -               PASS
+    test3   PASS            PASS
+    """
     planname_split_index = 0
     testname_split_index = 0
     if ARGS.short:


### PR DESCRIPTION
To become a real deal some new command line arguments still have to be introduced.
Currently 2 modes are possible (switch is controlled by --level2 argument) - show plans-list comparison or detailed tests-list comparison.

Resolves https://github.com/danmyway/tesar/issues/56