### PR TITLE
Accept testfilter and/or planfilter with plan option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).<br>
 - bump mapped convert2rhel composes/targets to Alma Linux and Rocky Linux 8.9, Oracle Linux 8.8
    (8.9 is absent on the AWS marketplace)
 - use all mapped compose targets when `-t/--target` not specified for the leapp-repository package
+- make `--plans`, `--planfilter` and `--testfilter` compatible
 ### Removed
 ## [2023.07.12]
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ The goal of tesar is to make requesting test jobs as easy as possible.<br>
 Instead of looking for build IDs to pass to the payload, all you need to know is a `--reference` for a pull request number associated with the build you need to test. For brew builds you just need to know the release version.<br>
 In case you have the Build ID handy, you can use that instead of the reference.<br>
 Use `-g/--git` to point from where the test metadata and code should be run. Specify the repository base e.g. github, repository owner and the branch from which the tests should run.<br>
-Multiple `--plans` can be specified and will be dispatched in separate jobs. The same applies to `--planfilter` and `--testfilter`.<br>
+Multiple `--plans` can be specified and will be dispatched in separate jobs.
+When using `--planfilter` or `--testfilter` to specify singular test it is disallowed to request multiple `--plans` in one command.<br>
 You can look for possible [targeted OS' below](#mapped-composes), multiple can be requested and will be dispatched in separate jobs.
 Use `-w/--wait` to override the default 20 seconds waiting time for successful response from the endpoint, or `-nw/--no-wait` to skip the wait time.
 If for any reason you would need the raw payload, use `--dry-run` to get it printed to the command line or use `--dry-run-cli` to print out the full usable `http POST` command.

--- a/src/dispatch/__init__.py
+++ b/src/dispatch/__init__.py
@@ -154,35 +154,33 @@ Default: '%(default)s'""",
         help="""Choose suitable architecture.\nDefault: '%(default)s'.""",
     )
 
-    fmf_reference = test.add_mutually_exclusive_group(required=True)
-
-    fmf_reference.add_argument(
+    test.add_argument(
         "-p",
         "--plans",
+        required=True,
         nargs="+",
         help="""Specify a test plan or multiple plans to request at testing farm.
 To run whole set of tiers use /plans/tier*/
 Accepts multiple space separated values, sends as a separate request.""",
     )
 
-    fmf_reference.add_argument(
+    test.add_argument(
         "-pf",
         "--planfilter",
-        nargs="+",
+        nargs="?",
         help="""Filter plans.
 The specified plan filter will be used in tmt plan ls --filter <YOUR-FILTER> command.
 By default enabled: true filter is applied.
-Accepts multiple space separated values, sends as a separate request.
 """,
     )
 
-    fmf_reference.add_argument(
+    test.add_argument(
         "-tf",
         "--testfilter",
-        nargs="+",
+        nargs="?",
         help="""Filter tests.
-The specified plan filter will be used in tmt run discover plan test --filter <YOUR-FILTER> command.
-Accepts multiple space separated values, sends as a separate request.""",
+The specified test filter will be used in tmt run discover plan test --filter <YOUR-FILTER> command.
+""",
     )
 
     test.add_argument(


### PR DESCRIPTION
* Previously the filters were mutually exclusive, which is unusable if one needs to specify one test ouf of many inside a plan
* make the filters compatible
* if the plans argument has more than one value with additional filters, exit

Fixes #45 