### PR TITLE
Make --skip-pass respected by test comparison mode

### DIFF
--- a/src/report/__main__.py
+++ b/src/report/__main__.py
@@ -318,7 +318,7 @@ def build_table_comparison():
     if ARGS.split_planname:
         planname_split_index = ARGS.split_planname
 
-    parsed_dict = parse_request_xunit()
+    parsed_dict = parse_request_xunit(skip_pass=ARGS.skip_pass)
     result_table = PrettyTable()
     uuids = list(parsed_dict.keys())
     fields = ["Test Plan"] + uuids


### PR DESCRIPTION
Let's fix this slight oversight so that tesar report --compare --skip-pass will be showing only problematic results.