### PR TITLE
Fix logging, append multiple -f options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 Pipfile*
 *__pycache__/
 *.egg-info/
-tesar_latest_jobs_*
+*tesar_latest_jobs_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Calendar Versioning](https://calver.org).<br>
 ### Added
 
 ### Changed
-
+* `-f/--file` can be passed multiple times, the task IDs get aggregated and reported in one table
 ### Removed
-
+* dropped Alma Linux and Rocky Linux 8.6 from the targets
 ## [2024.03.25]
 ### Added
 - Return code for report command

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Default invocation `tesar report` parses the `./report_jobs` from the tesar dire
 Results can be reported back in two levels - `l1` for plan overview and `l2` for tests overview.<br>
 You can chain the report command with test command and use the `-lt/--latest` and `-w/--wait` argument to get the results back whenever the requests state is complete (or error in which case the job results cannot be and won't be reported due to the non-existent xunit field).<br>
 `tesar test` automatically stores the request IDs from the latest dispatched job - the primary location to store and read the data from is `/tmp/latest_tesar_jobs` file. The file is also saved with a timestamp to the working directory just for a good measure.
-You can specify a different path to the file with `-f/--file` or pass the jobs to get report for straight to the commandline with `-c/--cmd`.<br>
+You can specify a different path to the file with `-f/--file` or pass the jobs to get report for straight to the commandline with `-c/--cmd`. Both can be used multiple times, the task IDs will get aggregated and reported in a single table.<br>
 The tool is able to parse and report for multiple variants of values as long as they are separated by a new-line (in the files) or a `-c/--cmd` argument (on the commandline). Raw request_ids, artifact URLs (Testing Farm result page URLs) or request URLs are allowed.
 In case you want to get the log files stored locally, use `-d/--download-logs`. Log files for pytest runs will be stored in `/var/tmp/tesar/logs/{request_id}_log/`. In case there are multiple plans in one pipeline, the logs should get divided in their respective plan directories.
 
@@ -255,10 +255,8 @@ Sadly, there is no instance of any relevance for CentOS 8 latest available.
 # RHEL8 targets
 cos8: CentOS-8-latest
 ol8: OL8.9-x86_64-HVM-2024-02-02
-al86: AlmaLinux OS 8.6.20220901 x86_64
 al88: AlmaLinux OS 8.8.20230524 x86_64
 al8: AlmaLinux OS 8.9.20231123 x86_64
-roc86: Rocky-8-ec2-8.6-20220515.0.x86_64
 roc88: Rocky-8-EC2-Base-8.8-20230518.0.x86_64
 roc8: Rocky-8-EC2-Base-8.9-20231119.0.x86_64
 str8: CentOS-Stream-8

--- a/src/tesar/dispatch/__init__.py
+++ b/src/tesar/dispatch/__init__.py
@@ -330,6 +330,7 @@ The specified test filter will be used in tmt run discover plan test --filter <Y
     tasks_source.add_argument(
         "-f",
         "--file",
+        action="append",
         help=f"""{FormatText.bold}Mutually exclusive with respect to --latest and --cmd.{FormatText.end}
         Specify a different location than the default {dispatch_globals.DEFAULT_TASKS_FILE} of the file containing request_id's, artifact URLs or request URLs.""",
     )

--- a/src/tesar/dispatch/copr_api.py
+++ b/src/tesar/dispatch/copr_api.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from copr.v3 import BuildProxy
 
 from . import dispatch_globals
-from . import get_arguments, get_compose_mapping, get_logging
+from .__init__ import get_arguments, get_compose_mapping, get_logging
 
 SESSION = BuildProxy(dispatch_globals.COPR_CONFIG)
 LOGGER = get_logging()

--- a/src/tesar/dispatch/dispatch_globals.py
+++ b/src/tesar/dispatch/dispatch_globals.py
@@ -65,11 +65,6 @@ C2R_COMPOSE_MAPPING = {
         "distro": "oracle-8-latest",
         "chroot": "epel-8-x86_64",
     },
-    "al86": {
-        "compose": "AlmaLinux OS 8.6.20220901 x86_64",
-        "distro": "alma-8.6",
-        "chroot": "epel-8-x86_64",
-    },
     "al88": {
         "compose": "AlmaLinux OS 8.8.20230524 x86_64",
         "distro": "alma-8.8",
@@ -78,11 +73,6 @@ C2R_COMPOSE_MAPPING = {
     "al8": {
         "compose": "AlmaLinux OS 8.9.20231123 x86_64",
         "distro": "alma-8-latest",
-        "chroot": "epel-8-x86_64",
-    },
-    "roc86": {
-        "compose": "Rocky-8-ec2-8.6-20220515.0.x86_64",
-        "distro": "rocky-8.6",
         "chroot": "epel-8-x86_64",
     },
     "roc88": {

--- a/src/tesar/dispatch/tf_send_request.py
+++ b/src/tesar/dispatch/tf_send_request.py
@@ -22,11 +22,6 @@ CLOUD_RESOURCES_TAG, TESTING_FARM_API_KEY = get_config()
 ARGS = get_arguments()
 OUTPUT_DIVIDER = 20 * "="
 
-# For some images (Alma, Rocky) we need to use post-install-script to enable root login.
-POST_INSTALL_SCRIPT = (
-    "#!/bin/bash\nsudo sed -i 's/^.*ssh-rsa/ssh-rsa/' /root/.ssh/authorized_keys"
-)
-
 if os.path.exists(LATEST_TASKS_FILE):
     os.unlink(LATEST_TASKS_FILE)
 
@@ -59,6 +54,13 @@ def submit_test(
     """
     Payload documentation > https://testing-farm.gitlab.io/api/#operation/requestsPost
     """
+
+    # We need to import new gpg key for Alma 8.8 to be able to test brew builds
+    if tmt_distro == "alma-8.8":
+        POST_INSTALL_SCRIPT = "#!/bin/bash\nsudo sed -i 's/^.*ssh-rsa/ssh-rsa/' /root/.ssh/authorized_keys; rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux"
+    else:
+        # For some images (Alma, Rocky) we need to use post-install-script to enable root login.
+        POST_INSTALL_SCRIPT = "#!/bin/bash\nsudo sed -i 's/^.*ssh-rsa/ssh-rsa/' /root/.ssh/authorized_keys"
 
     payload_raw = {
         "api_key": api_key,

--- a/src/tesar/report/__main__.py
+++ b/src/tesar/report/__main__.py
@@ -14,6 +14,7 @@ from ..dispatch.dispatch_globals import (
     TESTING_FARM_ENDPOINT,
     LATEST_TASKS_FILE,
     DEFAULT_TASKS_FILE,
+    C2R_COMPOSE_MAPPING,
 )
 
 ARGS = get_arguments()
@@ -48,17 +49,26 @@ def parse_tasks():
             tasks_source = LATEST_TASKS_FILE
             tasks_source_data = open(tasks_source).readlines()
         else:
-            print(
-                f"The path to the latest jobs file {LATEST_TASKS_FILE} does not exist!\nDo not use --latest to parse the default {DEFAULT_TASKS_FILE} path.\nOR\nuse --file for custom path."
+            LOGGER.critical(
+                f"The path to the latest jobs file {LATEST_TASKS_FILE} does not exist!"
+            )
+            LOGGER.critical(
+                f"Do not use --latest option if you wish to parse values of the default {DEFAULT_TASKS_FILE} path."
+            )
+            LOGGER.critical(
+                "Or use the --file option with path to a file containing the job IDs."
             )
             sys.exit(1)
     elif ARGS.file:
-        if os.path.exists(str(ARGS.file)):
-            tasks_source = ARGS.file
-            tasks_source_data = open(tasks_source).readlines()
-        else:
-            print(f"Given path {ARGS.file} does not exist!")
-            sys.exit(1)
+        tasks_source = ARGS.file
+        tasks_source_data = []
+        for file in tasks_source:
+            if os.path.exists(file):
+                task_ids = open(file).readlines()
+                tasks_source_data.extend(task_ids)
+            else:
+                LOGGER.critical(f"Given path {ARGS.file} does not exist!")
+                sys.exit(1)
     elif ARGS.cmd:
         tasks_source_data = ARGS.cmd
     else:
@@ -66,8 +76,9 @@ def parse_tasks():
             tasks_source = DEFAULT_TASKS_FILE
             tasks_source_data = open(tasks_source).readlines()
         else:
-            print(
-                f"Default file containing tasks doesn't exist.\nPass the tasks with --url or create and feed the {DEFAULT_TASKS_FILE}"
+            LOGGER.critical(f"The default file containing tasks doesn't exist.")
+            LOGGER.critical(
+                f"Pass the job IDs with the --cmd option or create and feed the {DEFAULT_TASKS_FILE} with job IDs."
             )
             sys.exit(1)
 
@@ -83,7 +94,7 @@ def parse_tasks():
         elif task == str(uuid.UUID(task)):
             task = TESTING_FARM_ENDPOINT + "/" + task
         else:
-            print(f"Unrecognized task {task}")
+            LOGGER.warning(f"Unrecognized task {task}")
             update_retval(NO_RESULT)
             continue
 
@@ -105,8 +116,8 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
     if request_url_list is None or tasks_source is None:
         request_url_list, tasks_source = parse_tasks()
     if len(request_url_list) == 0 or all(element == "" for element in request_url_list):
-        print("There are no tasks to report for.")
-        print(
+        LOGGER.critical("There are no tasks to report for.")
+        LOGGER.critical(
             f"Verify the {tasks_source} has at least one task in it or pass the values to the commandline with -c/--cmd."
         )
         sys.exit(1)
@@ -117,7 +128,7 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
     loading_chars = ["/", "-", "\\", "|"]
     index = 0
 
-    print("Reporting for the requested tasks:")
+    LOGGER.info("Reporting for the requested tasks:")
     for url in request_url_list:
         LOGGER.debug(f"Getting results of '{url}'")
         request = requests.get(url)
@@ -127,6 +138,7 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
         request_arch = request.json()["environments_requested"][0]["arch"]
         request_datetime_created = request.json()["created"]
         request_datetime_parsed = request_datetime_created.split(".")[0]
+        request_plan = request.json()["test"]["fmf"]["name"]
 
         log_dir = f"{request_uuid}_logs"
 
@@ -139,11 +151,11 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
         elif request_state == "ERROR":
             request_state = FormatText.bg_yellow + request_state + FormatText.bg_default
             update_retval(ERROR_HERE)
-        print(
-            request.json()["environments_requested"][0]["os"]["compose"],
-            request.json()["test"]["fmf"]["name"],
-            url,
-            request_state,
+
+        compose_len = _eval_longest_compose()
+
+        LOGGER.info(
+            f"{FormatText.bold}{FormatText.blue}{str(request_target):<{compose_len}} {request_plan:<20}{FormatText.end} {url} {request_state}"
         )
 
         if ARGS.wait:
@@ -161,28 +173,31 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
                 time.sleep(30)
                 request = requests.get(url)
             else:
-                print("Job finished!")
+                LOGGER.info("Job finished!")
         else:
             if (
                 request.json()["state"] != "complete"
                 and request.json()["state"] != "error"
             ):
-                print(
-                    f"Request {url} is still running, wait for it to finish or use --wait.\nSkipping to next request."
+                LOGGER.warning(
+                    f"Request {url} is still running, wait for it to finish or use --wait."
                 )
+                LOGGER.info("Skipping to the next request.")
+                print("\n")
                 update_retval(NO_RESULT)
                 continue
 
+        request_summary = request.json()["result"]["summary"]
+        request_result_overall = request.json()["result"]["overall"]
         if request.json()["state"] == "error":
-            request_summary = request.json()["result"]["summary"]
-            request_result_overall = request.json()["result"]["overall"]
+
             error_formatted = FormatText.bg_red + "ERROR" + FormatText.bg_default
             error_reason = request_summary
             message = (
                 f"Request ended up in {error_formatted} state, because {error_reason}.\n"
                 f"See more details on the result page {url.replace(TESTING_FARM_ENDPOINT, ARTIFACT_BASE_URL)}"
             )
-            print(FormatText.bold + message + FormatText.end)
+            LOGGER.critical(FormatText.bold + message + FormatText.end)
             update_retval(ERROR_HERE)
             # NOTE(ivasilev) There is a way to retrieve results even when the xunit file is not there, so let's not
             # skip tests processing upon error. Kudos to mmacura.
@@ -190,7 +205,7 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
         xunit = request.json()["result"]["xunit"]
         # TODO(mmacura): possibly always use artifacts/results.xml url instead of xunit in the TF endpoint
         if not xunit:
-            results_xml_url = request.json()["run"]["artifacts"] + "/results.xml"
+            results_xml_url = request.json()["result"]["xunit_url"]
             results_xml_response = requests.get(results_xml_url)
             if results_xml_response:
                 xunit = results_xml_response.text
@@ -246,7 +261,7 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
             continue
 
         if ARGS.download_logs:
-            print("  > Downloading the log files.")
+            LOGGER.info("  > Downloading the log files.")
             # Create the log directory path for the request
             log_dir_path = os.path.join(logs_base_directory, log_dir)
             os.makedirs(log_dir_path, exist_ok=True)
@@ -267,7 +282,7 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
                     "./testing-environment/property[@name='arch']/@value"
                 )[0]
             except IndexError:
-                testsuite_arch = elem.xpath("./@name")[0].split(":")[1]
+                testsuite_arch = elem.xpath("./@name")[0].split(":")[-1]
             testsuite_result = elem.xpath("./@result")[0].upper()
             testsuite_test_count = elem.xpath("./@tests")
             testsuite_log_dir = testsuite_name.split("/")[-1]
@@ -324,7 +339,7 @@ def parse_request_xunit(request_url_list=None, tasks_source=None, skip_pass=Fals
                         logfile.write(log_data)
 
         if ARGS.download_logs:
-            print(f"    > Logfiles stored in {log_dir_path}")
+            LOGGER.info(f"    > Logfiles stored in {log_dir_path}")
 
     return parsed_dict
 
@@ -537,6 +552,22 @@ def colorize(result, label=None, color_format_default=FormatText.end):
     """
     label = label if label else result
     return get_color_format(result) + label + color_format_default
+
+
+def _eval_longest_compose():
+    """
+    Helper function evaluating the longest compose name in the mapping.
+    Returns len int of the longest.
+    """
+    compose_len = 0
+    for nest_dict in C2R_COMPOSE_MAPPING.values():
+        eval_compose_len = len(nest_dict.get("compose"))
+        if eval_compose_len > compose_len:
+            compose_len = len(nest_dict.get("compose"))
+
+    compose_len = compose_len + 5
+
+    return compose_len
 
 
 def main(result_table=None):


### PR DESCRIPTION
* fixes #74 duplicate logging
* call the logger instance whenever possible in the report module
* make the `-f/--file` appendable 
  * aggregate the task IDs from multiple files provided on the commandline
* drop 8.6
* adjust tf_post_install_script for Alma 8.8 due to failing build installation (import the new gpg key)
* make report formatting nicer